### PR TITLE
CGLT139 - [FIX] Loan Document download error fixed

### DIFF
--- a/app/scripts/controllers/loanAccount/ViewLoanDetailsController.js
+++ b/app/scripts/controllers/loanAccount/ViewLoanDetailsController.js
@@ -1,6 +1,6 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
-        ViewLoanDetailsController: function (scope, routeParams, resourceFactory,paginatorService, location, route, http, $uibModal, dateFilter, API_VERSION, $sce, $rootScope, $window, interval, webStorage) {
+        ViewLoanDetailsController: function (scope, routeParams, resourceFactory,paginatorService, location, route, http, $uibModal, dateFilter, API_VERSION, $sce, $rootScope, $window, interval, webStorage, localStorageService) {
             scope.loandocuments = [];
             scope.report = false;
             scope.hidePentahoReport = true;
@@ -898,6 +898,13 @@
                 var url = scope.hostUrl + document.docUrl;
                 var sessionData = webStorage.get('sessionData');
                 var headers = { "Authorization": "Basic " + sessionData.authenticationKey };
+
+                var userData = localStorageService.getFromLocalStorage('userData');
+
+                if (userData.isTwoFactorAuthenticationRequired && userData.authenticated){
+                    headers["Fineract-Platform-TFA-Token"] = http.defaults.headers.common['Fineract-Platform-TFA-Token'];
+                }
+
                 fetch(url, {
                     method: 'GET',
                     headers
@@ -1087,7 +1094,7 @@
 
 
     });
-    mifosX.ng.application.controller('ViewLoanDetailsController', ['$scope', '$routeParams', 'ResourceFactory','PaginatorService', '$location', '$route', '$http', '$uibModal', 'dateFilter', 'API_VERSION', '$sce', '$rootScope','$window', '$interval', 'webStorage', mifosX.controllers.ViewLoanDetailsController]).run(function ($log) {
+    mifosX.ng.application.controller('ViewLoanDetailsController', ['$scope', '$routeParams', 'ResourceFactory','PaginatorService', '$location', '$route', '$http', '$uibModal', 'dateFilter', 'API_VERSION', '$sce', '$rootScope','$window', '$interval', 'webStorage', 'localStorageService', mifosX.controllers.ViewLoanDetailsController]).run(function ($log) {
         $log.info("ViewLoanDetailsController initialized");
     });
 }(mifosX.controllers || {}));


### PR DESCRIPTION
## Description
When 2FA is enabled loan documents cannot be dowloaded. Upon investigation it was found that the 2fa token header was missing in the request and thus a 403 error is returned. This is because in the function downloadDocument in the controller ViewLoanDetailsController failed to add all the relevant headers.

**Proposed Code Changes**

1. Add the  `Fineract-Platform-TFA-Token` header to the request if two factor authentication is required and the user is authenticated. 

 Files to be modified:

1. `ViewLoanDetailsController.js`